### PR TITLE
Include version information in module descriptors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ static isSnapshotRelease(versionString) {
 plugins {
 	id 'org.jetbrains.kotlin.jvm' version "1.5.31" apply false
 	id 'org.jetbrains.dokka' version "1.5.31" apply false
-	id 'org.beryx.jar' version "2.0.0-rc-1" apply false
+	id 'org.beryx.jar' version "2.0.0-rc-2" apply false
 }
 
 ext {


### PR DESCRIPTION
## Overview

Include version information in module descriptors by upgrading modularity plugin to `2.0.0-rc-2`.

See https://github.com/beryx/badass-jar-plugin#module-version for details

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
